### PR TITLE
Fixing Player leaving table + minor performance increase

### DIFF
--- a/HandHistories.Parser.UnitTests/HandHistories.Parser.UnitTests.csproj
+++ b/HandHistories.Parser.UnitTests/HandHistories.Parser.UnitTests.csproj
@@ -1006,6 +1006,9 @@
     <Content Include="SampleHandHistories\PokerStars\CashGame\HandActionTests\BigBlindOptionRaisesOption.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="SampleHandHistories\PokerStars\CashGame\HandActionTests\LeavesTableMidHand.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="SampleHandHistories\PokerStars\CashGame\HandActionTests\StrangePlayerNames.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/HandHistories.Parser.UnitTests/Parsers/HandParserTests/HandActionTests/HandParserHandActionTestsPokerStarsImpl.cs
+++ b/HandHistories.Parser.UnitTests/Parsers/HandParserTests/HandActionTests/HandParserHandActionTestsPokerStarsImpl.cs
@@ -12,6 +12,30 @@ namespace HandHistories.Parser.UnitTests.Parsers.HandParserTests.HandActionTests
         {
         }
 
+
+        [Test]
+        public void PlayerLeavesTableMidHand_Works()
+        {
+            List<HandAction> expectedActions = new List<HandAction>()
+                {
+                    new HandAction("Plz3betMe", HandActionType.SMALL_BLIND, 0.5m, Street.Preflop),
+                    new HandAction("Luxuswasser", HandActionType.BIG_BLIND, 1m, Street.Preflop),
+
+                    new HandAction("JJScvbnm", HandActionType.RAISE, 2, Street.Preflop),
+                    new HandAction("Mark_999dk", HandActionType.FOLD, 0m, Street.Preflop),
+                    new HandAction("BSTUSim", HandActionType.FOLD, 0m, Street.Preflop),
+                    new HandAction("nanotehn77", HandActionType.FOLD, 0, Street.Preflop),
+                    new HandAction("Plz3betMe", HandActionType.FOLD, 0, Street.Preflop),
+                    new HandAction("Luxuswasser", HandActionType.FOLD, 0, Street.Preflop),
+
+                    new HandAction("JJScvbnm", HandActionType.UNCALLED_BET, 2, Street.Preflop),
+                    new WinningsAction("JJScvbnm", HandActionType.WINS, 2.50m, 0),
+                    new HandAction("JJScvbnm", HandActionType.MUCKS,0, Street.Showdown)
+                };
+
+            TestParseActions("LeavesTableMidHand", expectedActions);
+        }
+
         [Test]
         public void StrangePlayerNames_Works()
         {

--- a/HandHistories.Parser.UnitTests/Parsers/HandParserTests/HandActionTests/HandParserHandActionTestsPokerStarsImpl.cs
+++ b/HandHistories.Parser.UnitTests/Parsers/HandParserTests/HandActionTests/HandParserHandActionTestsPokerStarsImpl.cs
@@ -21,7 +21,7 @@ namespace HandHistories.Parser.UnitTests.Parsers.HandParserTests.HandActionTests
                     new HandAction("Plz3betMe", HandActionType.SMALL_BLIND, 0.5m, Street.Preflop),
                     new HandAction("Luxuswasser", HandActionType.BIG_BLIND, 1m, Street.Preflop),
 
-                    new HandAction("JJScvbnm", HandActionType.RAISE, 2, Street.Preflop),
+                    new HandAction("JJScvbnm", HandActionType.RAISE, 3, Street.Preflop),
                     new HandAction("Mark_999dk", HandActionType.FOLD, 0m, Street.Preflop),
                     new HandAction("BSTUSim", HandActionType.FOLD, 0m, Street.Preflop),
                     new HandAction("nanotehn77", HandActionType.FOLD, 0, Street.Preflop),

--- a/HandHistories.Parser.UnitTests/SampleHandHistories/PokerStars/CashGame/HandActionTests/LeavesTableMidHand.txt
+++ b/HandHistories.Parser.UnitTests/SampleHandHistories/PokerStars/CashGame/HandActionTests/LeavesTableMidHand.txt
@@ -1,0 +1,32 @@
+﻿PokerStars Game #113004443741:  Hold'em No Limit ($0.50/$1.00 USD) - 2014/03/09 11:32:57 ET
+Table 'Charon III 40-100 bb' 9-max Seat #8 is the button
+Seat 3: Luxuswasser ($117.41 in chips) 
+Seat 4: JJScvbnm ($108.73 in chips) 
+Seat 5: Mark_999dk ($50.97 in chips) 
+Seat 7: BSTUSim ($220.31 in chips) 
+Seat 8: nanotehn77 ($39 in chips) 
+Seat 9: Plz3betMe ($37.81 in chips) 
+Plz3betMe: posts small blind $0.50
+Kuca :P: is sitting out 
+Luxuswasser: posts big blind $1
+*** HOLE CARDS ***
+Kuca :P leaves the table
+JJScvbnm: raises $2 to $3
+Mark_999dk: folds 
+BSTUSim: folds 
+nanotehn77: folds 
+Plz3betMe: folds 
+Luxuswasser: folds 
+Uncalled bet ($2) returned to JJScvbnm
+JJScvbnm collected $2.50 from pot
+JJScvbnm: doesn't show hand 
+*** SUMMARY ***
+Total pot $2.50 | Rake $0 
+Seat 3: Luxuswasser (big blind) folded before Flop
+Seat 4: JJScvbnm collected ($2.50)
+Seat 5: Mark_999dk folded before Flop (didn't bet)
+Seat 7: BSTUSim folded before Flop (didn't bet)
+Seat 8: nanotehn77 (button) folded before Flop (didn't bet)
+Seat 9: Plz3betMe (small blind) folded before Flop
+
+

--- a/HandHistories.Parser/Parsers/FastParser/PokerStars/PokerStarsFastParserImpl.cs
+++ b/HandHistories.Parser/Parsers/FastParser/PokerStars/PokerStarsFastParserImpl.cs
@@ -387,49 +387,6 @@ namespace HandHistories.Parser.Parsers.FastParser.PokerStars
                     default:
                         throw new HandActionException(line, "Unrecognized line w/ a *:" + line);
                 }
-                ////*** HOLE CARDS ***
-                //if (typeOfEventChar == 'H')
-                //{
-                //    currentStreet = Street.Preflop;
-                //    return false;
-                //}
-                ////*** FLOP *** [6d 4h Jc]
-                //else if (typeOfEventChar == 'F')
-                //{
-                //    currentStreet = Street.Flop;
-                //    return false;
-                //}
-                ////*** TURN *** [6d 4h Jc] [5s]
-                //else if (typeOfEventChar == 'T')
-                //{
-                //    currentStreet = Street.Turn;
-                //    return false;
-                //}
-                ////*** RIVER *** [6d 4h Jc 5s] [6h]
-                //else if (typeOfEventChar == 'R')
-                //{
-                //    currentStreet = Street.River;
-                //    return false;
-                //}
-                ////*** SHOW DOWN ***
-                ////*** SUMMARY ***
-                //else if (typeOfEventChar == 'S')
-                //{
-                //    if (line[5] == 'H')
-                //    {
-                //        currentStreet = Street.Showdown;
-                //        return false;
-                //    }
-                //    else
-                //    {
-                //        // we are done at the summary line
-                //        return true;
-                //    }
-                //}
-                //else
-                //{
-                //    throw new HandActionException(line, "Unrecognized line w/ a *:" + line);
-                //}
             }
 
             if (currentStreet == Street.Preflop &&
@@ -509,8 +466,8 @@ namespace HandHistories.Parser.Parsers.FastParser.PokerStars
                 case Street.Null:
                     // Can have non posting action lines:
                     //    Craftyspirit: is sitting out                   
-                    if (lastChar == 't' || // sitting out line
-                        lastChar == 'n') // play after button line
+                    if (lastChar == 't' || // sitting out
+                        lastChar == 'n') // play after button
                     {
                         return false;
                     }


### PR DESCRIPTION
When a player name contains a colon and leaves a table it causes an
error.

Restructuring the ParseHandActions() code + minor performance
improvements.